### PR TITLE
Fix createZip.sh when the branch name contains a slash

### DIFF
--- a/createZip.sh
+++ b/createZip.sh
@@ -5,7 +5,8 @@ DESTINATION_FOLDER=".."
 DEFAULT_SCENARIO=basic_scenario
 COMMON_FOLDER=_common
 
-CURRENT_BRANCH=$(git branch --show-current)
+# the branch name ends up in a file name, slashes would turn it into a path
+CURRENT_BRANCH=$(git branch --show-current | tr '/' '-')
 
 function show_help {
     echo Usage "$0" [-hv] SCENARIO_NAME
@@ -66,7 +67,7 @@ if [ ! -d "$SCENARIO_NAME" ]; then
     exit 1;
 fi
 
-if [ $SCENARIO_NAME = $DEFAULT_SCENARIO ]; then
+if [ "$SCENARIO_NAME" = "$DEFAULT_SCENARIO" ]; then
     NAME=gameModel_${CURRENT_BRANCH}_$(date +%Y-%m-%d_%Hh%M)
 else
     NAME=${SCENARIO_NAME}_gameModel_${CURRENT_BRANCH}_$(date +%Y-%m-%d_%Hh%M)


### PR DESCRIPTION
## Problem

`createZip.sh` interpolates the current branch name into the zip file name. On a
branch such as `claude/some-work` the name stops being a file name and becomes a
path, and the run fails in a way that still reports success:

```
zip I/O error: No such file or directory
zip error: Could not create output file (gameModel_claude/some-work_2026-08-06_15h48.zip)
mv: rename gameModel_claude/some-work_....zip to ../....zip: No such file or directory
Done

Zip file is gameModel_claude/some-work_2026-08-06_15h48.zip
```

What makes it awkward to diagnose is how far it gets first:

| Line | Behaviour |
|---|---|
| 85 | `mkdir -p "${NAME}"/gameModel` **succeeds** — `-p` creates the intermediate folder |
| 88‑89 | the copy succeeds, all data is in place |
| 92 | `cd "${NAME}"` succeeds |
| 93 | `zip … "${NAME}".zip` resolves the slash against the *new* working directory and fails |
| 94 | `mv` fails, the zip was never created |
| 98 | `rm -R "${NAME}"` removes the inner folder, leaving an empty one behind |

The script then prints `Done` and a path to a file that does not exist. The empty
folder is invisible to `git status`, since git does not track empty directories.

Branch names without a slash (`MIM-696`, `MIM-659`, …) are unaffected, which is why
this has not shown up before.

## Change

Replace slashes in the branch name so it stays a file name:

```bash
CURRENT_BRANCH=$(git branch --show-current | tr '/' '-')
```

`claude/some-work` now yields `gameModel_claude-some-work_2026-08-06_15h48.zip`.
Names without a slash pass through `tr` unchanged, so existing behaviour is
untouched.

Also quotes both sides of the default scenario comparison on line 69. Unquoted, a
scenario folder whose name contains a space is word split, so `test` receives four
arguments instead of three and prints `[: too many arguments`. It does not select
the wrong branch today, because `DEFAULT_SCENARIO` has no space and the branch it
falls into is the correct one regardless — the message is just noise, and the
quoting removes a trap if that default ever changes.

## Testing

Verified on a branch deliberately named with a slash
(`fix/createzip-slash-in-branch-name`):

- produces `gameModel_fix-createzip-slash-in-branch-name_<date>.zip`, 5.0 MB, 549
  entries — 357 under `gameModel/libs`, 103 under `gameModel/pages`, plus
  `gamemodel.json` and `filesmeta.json`
- the zip passes the same `gameModel/` validation that `updateFromZip.sh` applies to
  an export
- the temporary folder is cleaned up, nothing left behind
- with a scenario folder named `my scenario`: unquoted prints
  `line 70: [: too many arguments`, quoted is clean, both producing the same zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
